### PR TITLE
Disable concurrency 

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: IntegrationTests
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21.0
       id: go

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: IntegrationTests
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.0
       -


### PR DESCRIPTION
The provider's integration tests should not be run concurrently. This PR fixes it.